### PR TITLE
Mention user instead of using author displayname

### DIFF
--- a/src/interactions/info.ts
+++ b/src/interactions/info.ts
@@ -256,7 +256,7 @@ async function formatMessageReference(message: Message): Promise<string> {
         const referredMessage = await message.fetchReference();
         const externalServerConfig = referredMessage.guildId ? getServerConfig(referredMessage.guildId) : undefined;
 
-        const referredMessageStr = `${referredMessage.author.displayName}: ${referredMessage.content}`;
+        const referredMessageStr = `<@${referredMessage.author.id}>: ${referredMessage.content}`;
         return `${referredMessageStr}\n\n${(externalServerConfig ? `[Jump to referenced message](${referredMessage.url})` : '*(Message outside of server)*')}`;
     } catch (err: any) {
         if (err.code === "GuildChannelResolve") {


### PR DESCRIPTION
Since we only log referenced messages in this fashion if they come from the server, it only makes sense to mention the user instead of relying on displaynames.